### PR TITLE
enable rotating log file

### DIFF
--- a/mongo_connector/constants.py
+++ b/mongo_connector/constants.py
@@ -22,3 +22,10 @@ DEFAULT_COMMIT_INTERVAL = None
 # DocManager. This only affects DocManagers that cannot stream their
 # requests.
 DEFAULT_MAX_BULK = 500
+# ROTATING LOGFILE
+# The type of interval (seconds, minutes, hours... cf TimedRotatingFileHandler class)
+DEFAULT_LOGFILE_WHEN = "midnight"
+# The rollover interval
+DEFAULT_LOGFILE_INTERVAL = 1
+# Number of log file to keep
+DEFAULT_LOGFILE_BACKUPCOUNT = 7


### PR DESCRIPTION
I don't know if I made a good implementation because I don't know python very well, but the idea is to enable a rotating file in order to have few small files instead of a big one which keeps growing.

This PR is not very flexible but I'll be able to set the "when", "interval" and "backCount" parameters of the TimedRotatingFileHandler in the constants.py

But in a first time, I want your advice about this feature