### PR TITLE
Protect AttributeError: 'NoneType' object has no attribute 'get'

### DIFF
--- a/mongo_connector/doc_managers/mongo_doc_manager.py
+++ b/mongo_connector/doc_managers/mongo_doc_manager.py
@@ -155,7 +155,7 @@ class DocManager(DocManagerBase):
 
         doc2 = self.mongo['__mongo_connector'][namespace].find_and_modify(
             {'_id': document_id}, remove=True)
-        if doc2.get('gridfs_id'):
+        if (doc2 and doc2.get('gridfs_id')):
             GridFS(self.mongo[database], coll).delete(doc2['gridfs_id'])
         else:
             self.mongo[database][coll].remove({'_id': document_id})


### PR DESCRIPTION
Solves the exception:

```
Logging to mongo-connector.log.
Exception in thread Thread-2:
Traceback (most recent call last):
  File "/usr/lib64/python2.6/threading.py", line 532, in __bootstrap_inner
    self.run()
  File "/usr/lib/python2.6/site-packages/mongo_connector/util.py", line 85, in wrapped
    func(*args, **kwargs)
  File "/usr/lib/python2.6/site-packages/mongo_connector/oplog_manager.py", line 240, in run
    entry['o']['_id'], ns, timestamp)
  File "/usr/lib/python2.6/site-packages/mongo_connector/util.py", line 32, in wrapped
    return f(*args, **kwargs)
  File "/usr/lib/python2.6/site-packages/mongo_connector/doc_managers/mongo_doc_manager.py", line 158, in remove
    if doc2.get('gridfs_id'):
AttributeError: 'NoneType' object has no attribute 'get'
```