### PR TITLE
Add read preference option for mongo

### DIFF
--- a/config.json
+++ b/config.json
@@ -3,6 +3,7 @@
     "__comment__": "To enable them, remove the preceding '__'",
 
     "mainAddress": "localhost:27017",
+    "readPref": "primary",
     "oplogFile": "/var/log/mongo-connector/oplog.timestamp",
     "noDump": false,
     "batchSize": -1,


### PR DESCRIPTION
In order to reduce the load on the primaries having the secondaries take over the oplog cursor load is a nice to have.